### PR TITLE
Added test tube and beaker use for alchemy skill

### DIFF
--- a/lib/achievements/stats.dart
+++ b/lib/achievements/stats.dart
@@ -156,6 +156,7 @@ class StatManager {
 enum Stat {
 	awesome_pot_uses,
 	barnacles_scraped,
+    beaker_uses,
 	bean_trees_petted,
 	bean_trees_watered,
 	beans_harvested,
@@ -225,6 +226,7 @@ enum Stat {
 	spice_plants_petted,
 	spice_plants_watered,
 	steps_taken,
+    test_tube_uses,
 	tinkertool_uses,
 	wood_trees_petted,
 	wood_trees_watered

--- a/lib/achievements/statsbased.dart
+++ b/lib/achievements/statsbased.dart
@@ -17,7 +17,8 @@ class StatAchvManager {
 		"saucepan": simmer,
 		"smelter": smelt,
 		"spice_mill": mill,
-		"tinkertool": tinker
+		"tinkertool": tinker,
+        "test_tube": concoct,
 	};
 
 	static void update(String email, String toolType) {
@@ -48,9 +49,32 @@ class StatAchvManager {
                 });
 	}
 
-	static void stir(String email) {
-		SkillManager.learn("alchemy", email);
-	}
+    static void stir(String email) {
+        SkillManager.learn("alchemy", email);
+        StatManager.add(email, Stat.beaker_uses).then((int uses) {
+                if (uses >= 41) {
+                Achievement.find("senior-admixificator").awardTo(email);
+                } else if (uses >= 11) {
+                Achievement.find("midlevel-admixificator").awardTo(email);
+                } else if (uses >= 3) {
+                Achievement.find("entrylevel-admixificator").awardTo(email);
+                }
+                });
+    }
+
+    static void concoct(String email) {
+        SkillManager.learn("alchemy", email);
+        StatManager.add(email, Stat.test_tube_uses).then((int uses) {
+                if (uses >= 5011) {
+                Achievement.find("loyal-alloyer").awardTo(email);
+                } else if (uses >= 503) {
+                Achievement.find("really-unconfounded-compounder").awardTo(email);
+                } else if (uses >= 41) {
+                Achievement.find("unconfounded-compounder").awardTo(email);
+                }
+                });
+    }
+
 
 	static void seasonBeans(String email) {
 		StatManager.add(email, Stat.beans_seasoned).then((int seasoned) {


### PR DESCRIPTION
Fixes https://github.com/ChildrenOfUr/cou-issues/issues/1491.
Andy added the rows in the database for test_tube_uses and beaker_uses. 
Tested ok on local instance. 